### PR TITLE
fixed minifying css-files 

### DIFF
--- a/hooks/after_prepare/uglify.js
+++ b/hooks/after_prepare/uglify.js
@@ -133,7 +133,7 @@ function compress(file) {
 
             source = fs.readFileSync(file, 'utf8');
             result = cssMinifier.minify(source);
-            fs.writeFileSync(file, result, 'utf8'); // overwrite the original unminified file
+            fs.writeFileSync(file, result.styles, 'utf8'); // overwrite the original unminified file
             break;
 
         default:


### PR DESCRIPTION
according to the example on https://github.com/jakubpawlowicz/clean-css, the call minified css is in the styles-member

This fixes a problem that all css files only contain "[object object]".

Maybe this has changed in a newer version of clean-css. I didn't check that.